### PR TITLE
Preserve legacy manage_script actions, handle validation levels, and add framing safety check

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ManageScript.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScript.cs
@@ -187,9 +187,11 @@ namespace UnityMcpBridge.Editor.Tools
                         namespaceName
                     );
                 case "read":
-                    return Response.Error("Deprecated: reads are resources now. Use resources/read with a unity://path or unity://script URI.");
+                    Debug.LogWarning("manage_script.read is deprecated; prefer resources/read. Serving read for backward compatibility.");
+                    return ReadScript(fullPath, relativePath);
                 case "update":
-                    return Response.Error("Deprecated: use apply_text_edits (small, line/col edits) rather than whole-file replace.");
+                    Debug.LogWarning("manage_script.update is deprecated; prefer apply_text_edits. Serving update for backward compatibility.");
+                    return UpdateScript(fullPath, relativePath, name, contents);
                 case "delete":
                     return DeleteScript(fullPath, relativePath);
                 case "apply_text_edits":
@@ -204,7 +206,9 @@ namespace UnityMcpBridge.Editor.Tools
                     var chosen = level switch
                     {
                         "basic" => ValidationLevel.Basic,
+                        "standard" => ValidationLevel.Standard,
                         "strict" => ValidationLevel.Strict,
+                        "comprehensive" => ValidationLevel.Comprehensive,
                         _ => ValidationLevel.Standard
                     };
                     string fileText;
@@ -226,10 +230,13 @@ namespace UnityMcpBridge.Editor.Tools
                                : Response.Error("Validation failed.", result);
                 }
                 case "edit":
-                    return Response.Error("Deprecated: use apply_text_edits. Structured 'edit' mode has been retired in favor of simple text edits.");
+                    Debug.LogWarning("manage_script.edit is deprecated; prefer apply_text_edits. Serving structured edit for backward compatibility.");
+                    var edits = @params["edits"] as JArray;
+                    var options = @params["options"] as JObject;
+                    return EditScript(fullPath, relativePath, name, edits, options);
                 default:
                     return Response.Error(
-                        $"Unknown action: '{action}'. Valid actions are: create, read, update, delete."
+                        $"Unknown action: '{action}'. Valid actions are: create, delete, apply_text_edits, validate, read (deprecated), update (deprecated), edit (deprecated)."
                     );
             }
         }
@@ -581,10 +588,26 @@ namespace UnityMcpBridge.Editor.Tools
                 }
                 if (i == text.Length) break;
                 char c = text[i];
-                if (c == '\n') { line++; col = 1; }
-                else { col++; }
+                if (c == '\r')
+                {
+                    // Treat CRLF as a single newline; skip the LF if present
+                    if (i + 1 < text.Length && text[i + 1] == '\n')
+                        i++;
+                    line++;
+                    col = 1;
+                }
+                else if (c == '\n')
+                {
+                    line++;
+                    col = 1;
+                }
+                else
+                {
+                    col++;
+                }
             }
-            index = -1; return false;
+            index = -1;
+            return false;
         }
 
         private static string ComputeSha256(string contents)

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -1579,6 +1579,15 @@ namespace UnityMcpBridge.Editor.Windows
                                 }
                             }
                         }
+                        else
+                        {
+                            // Surface mismatch even if auto-manage is disabled
+                            mcpClient.SetStatus(McpStatus.IncorrectPath);
+                            if (debugLogsEnabled)
+                            {
+                                UnityEngine.Debug.Log($"UnityMCP: IDE config mismatch for '{mcpClient.name}' and auto-manage disabled");
+                            }
+                        }
                     }
                 }
                 else

--- a/UnityMcpBridge/UnityMcpServer~/src/pyrightconfig.json
+++ b/UnityMcpBridge/UnityMcpServer~/src/pyrightconfig.json
@@ -1,4 +1,11 @@
 {
   "typeCheckingMode": "basic",
-  "reportMissingImports": "none"
+  "reportMissingImports": "none",
+  "pythonVersion": "3.11",
+  "executionEnvironments": [
+    {
+      "root": ".",
+      "pythonVersion": "3.11"
+    }
+  ]
 }

--- a/test_unity_socket_framing.py
+++ b/test_unity_socket_framing.py
@@ -77,6 +77,9 @@ def main():
             s.sendall(header + body_bytes)
             resp_len = struct.unpack(">Q", recv_exact(s, 8))[0]
             print(f"Response framed length: {resp_len}")
+            MAX_RESP = 128 * 1024 * 1024
+            if resp_len <= 0 or resp_len > MAX_RESP:
+                raise RuntimeError(f"invalid framed length: {resp_len} (max {MAX_RESP})")
             resp = recv_exact(s, resp_len)
         else:
             s.sendall(body_bytes)


### PR DESCRIPTION
## Summary
- keep deprecated manage_script read/update/edit actions as compatibility aliases with warnings
- handle CRLF newlines correctly when mapping line/column to index
- flag IDE config mismatches when auto-manage is disabled
- support explicit 'basic', 'standard', 'strict', and 'comprehensive' validation levels
- cap framed response length in socket test
- pin Python 3.11 version for pyright

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a083d83a108327a0cb602fdeb3b1a7