### PR TITLE
Use long for edit byte totals to avoid overflow

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ManageScript.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScript.cs
@@ -465,7 +465,7 @@ namespace UnityMcpBridge.Editor.Tools
 
             // Convert edits to absolute index ranges
             var spans = new List<(int start, int end, string text)>();
-            int totalBytes = 0;
+            long totalBytes = 0;
             foreach (var e in edits)
             {
                 try
@@ -483,7 +483,10 @@ namespace UnityMcpBridge.Editor.Tools
                     if (eidx < sidx) (sidx, eidx) = (eidx, sidx);
 
                     spans.Add((sidx, eidx, newText));
-                    totalBytes += System.Text.Encoding.UTF8.GetByteCount(newText);
+                    checked
+                    {
+                        totalBytes += System.Text.Encoding.UTF8.GetByteCount(newText);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- switch ApplyTextEdits to track UTF-8 byte counts with `long`
- wrap byte count accumulation in `checked` to guard against overflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e82028f883279970e50b1fbf06e7