### PR TITLE
Add handshake fallback and logging checks

### DIFF
--- a/tests/test_logging_stdout.py
+++ b/tests/test_logging_stdout.py
@@ -48,12 +48,24 @@ def test_no_print_statements_in_codebase():
                 # print(...)
                 if isinstance(node.func, ast.Name) and node.func.id == "print":
                     self.hit = True
+                # builtins.print(...)
+                elif (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "print"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "builtins"
+                ):
+                    self.hit = True
                 # sys.stdout.write(...)
-                if isinstance(node.func, ast.Attribute) and node.func.attr == "write":
-                    val = node.func.value
-                    if isinstance(val, ast.Attribute) and val.attr == "stdout":
-                        if isinstance(val.value, ast.Name) and val.value.id == "sys":
-                            self.hit = True
+                if (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "write"
+                    and isinstance(node.func.value, ast.Attribute)
+                    and node.func.value.attr == "stdout"
+                    and isinstance(node.func.value.value, ast.Name)
+                    and node.func.value.value.id == "sys"
+                ):
+                    self.hit = True
                 self.generic_visit(node)
 
         v = StdoutVisitor()

--- a/tests/test_transport_framing.py
+++ b/tests/test_transport_framing.py
@@ -129,6 +129,7 @@ def test_unframed_data_disconnect():
     port = start_handshake_enforcing_server()
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", port))
+    sock.settimeout(1.0)
     sock.sendall(b"BAD")
     time.sleep(0.4)
     try:


### PR DESCRIPTION
## Summary
- extend stdout detection tests to cover builtins.print and collapse nested stdout.write logic
- guard unframed handshake test with a client socket timeout
- add configurable handshake requirements, lock-based IO serialization, and better debug logging for Unity connection

## Testing
- `pytest tests/test_logging_stdout.py tests/test_transport_framing.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a28f8913fc832789efbfb1ceb3af72