### PR TITLE
Fix ApplyTextEdits replacement index calculation and port probe handshake

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ManageScript.cs
+++ b/UnityMcpBridge/Editor/Tools/ManageScript.cs
@@ -557,13 +557,20 @@ namespace UnityMcpBridge.Editor.Tools
                             // If the edit overlaps the method span significantly, treat as replace_method
                             if (sp.start <= mStart + 2 && sp.end >= mStart + 1)
                             {
+                                var methodOriginal = original.Substring(mStart, mLen);
+                                int relStart = Math.Max(0, Math.Min(sp.start - mStart, methodOriginal.Length));
+                                int relEnd = Math.Max(relStart, Math.Min(sp.end - mStart, methodOriginal.Length));
+                                string replacementSnippet = methodOriginal
+                                    .Remove(relStart, relEnd - relStart)
+                                    .Insert(relStart, sp.text ?? string.Empty);
+
                                 var structEdits = new JArray();
                                 var op = new JObject
                                 {
                                     ["mode"] = "replace_method",
                                     ["className"] = name,
                                     ["methodName"] = methodName,
-                                    ["replacement"] = original.Remove(sp.start, sp.end - sp.start).Insert(sp.start, sp.text ?? string.Empty).Substring(mStart, (sp.text ?? string.Empty).Length + (sp.start - mStart) + (mLen - (sp.end - mStart)))
+                                    ["replacement"] = replacementSnippet
                                 };
                                 structEdits.Add(op);
                                 // Reuse structured path


### PR DESCRIPTION
## Summary
- Avoid invalid substring lengths when auto-upgrading ApplyTextEdits to replace_method
- Compute replacement snippet relative to the method span with clamped ranges
- Honor FRAMING=1 handshake when probing Unity MCP ports so framed ping/pong works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a296f62bcc8327addf3431c744a0da