### PR TITLE
fix: update Unity MCP server path in workflow

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -52,7 +52,7 @@ jobs:
               "mcpServers": {
                 "unity": {
                   "command": "python",
-                  "args": ["UnityMcpServer/src/server.py"]
+                  "args": ["UnityMcpBridge/UnityMcpServer~/src/server.py"]
                 }
               }
             }


### PR DESCRIPTION
## Summary
- fix workflow to point MCP server to correct path under UnityMcpBridge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4504828a8832787ba73ff2ad37e61