### PR TITLE
fix: update MCP server dependency path

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Prepare Unity MCP server deps (adjust path or remove if N/A)
         run: |
-          if [ -f UnityMcpServer/requirements.txt ]; then
-            uv pip install -r UnityMcpServer/requirements.txt
+          if [ -f UnityMcpBridge/UnityMcpServer~/src/pyproject.toml ]; then
+            uv pip install UnityMcpBridge/UnityMcpServer~/src
+          elif [ -f UnityMcpBridge/UnityMcpServer~/src/requirements.txt ]; then
+            uv pip install -r UnityMcpBridge/UnityMcpServer~/src/requirements.txt
           fi
 
       - name: Run Claude NL/T test suite


### PR DESCRIPTION
## Summary
- point workflow to install MCP server dependencies from UnityMcpBridge/UnityMcpServer~
- fall back to requirements.txt if present

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a451f30698832797aa449a592811b1