### PR TITLE
Gracefully handle invalid JUnit XML and pre-create report directory

### DIFF
--- a/.github/scripts/mark_skipped.py
+++ b/.github/scripts/mark_skipped.py
@@ -15,7 +15,11 @@ def main(path: str) -> None:
     p = pathlib.Path(path)
     if not p.exists():
         return
-    tree = ET.parse(p)
+    try:
+        tree = ET.parse(p)
+    except (ET.ParseError, FileNotFoundError) as e:
+        print(f"[mark_skipped] Failed to parse XML at {p}: {e}", file=sys.stderr)
+        return
     root = tree.getroot()
     changed = False
     for case in root.iter("testcase"):

--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -71,10 +71,8 @@ jobs:
           print("MCP tool modules present:", sorted(required))
           PY
 
-      - name: Prepare reports dir
-        run: |
-          set -eux
-          mkdir -p reports
+      - name: Ensure artifact dirs exist
+        run: mkdir -p reports
 
       - name: Log MCP server location (diagnostic)
         run: |


### PR DESCRIPTION
## Summary
- avoid crashing on malformed or missing JUnit reports by catching `ElementTree.ParseError` and `FileNotFoundError`
- create the `reports` directory before the Claude NL/T suite runs to keep filesystem operations outside the agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a558308acc8327ab2d583d2584ea80