### PR TITLE
Align CI permissions for Claude NL test workflow

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -123,11 +123,9 @@ jobs:
               }
             }
 
-      # Make CI non-interactive; names vary by action version:
-    # e.g. permission_mode: "auto"  OR  permissions: "approveAll"  OR  auto_approve_tools: "mcp__unity__*"
-    permission_mode: "auto"
-    auto_approve_tools: "mcp__unity__*,Read,Write"
-    allowed_tools: "Read,Write,Glob,Grep,mcp__unity__*"
+          # Make CI non-interactive; names vary by action version
+          permission_mode: "auto"                       # or use the action’s supported key
+          auto_approve_tools: "mcp__unity__*,Read,Write"
 
           # Guardrails
           model: "claude-3-7-sonnet-20250219"


### PR DESCRIPTION
## Summary
- Embed permission defaults in Claude NL/T workflow
- Remove extraneous allowed-tools line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5657fba6c83278b51c04fb4df0bcc