### PR TITLE
chore: configure CI permissions for claude tests

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -123,9 +123,19 @@ jobs:
               }
             }
 
-          # Make CI non-interactive; names vary by action version
-          permission_mode: "auto"                       # or use the action’s supported key
-          auto_approve_tools: "mcp__unity__*,Read,Write"
+            # ***This is what turns off the prompts in CI***
+            settings: |
+              {
+                "defaultMode": "bypassPermissions",
+                "permissionStorage": "none",
+                "permissions": {
+                  "allow": [
+                    "Read", "Write", "LS", "Glob", "Grep",
+                    "Bash(git:*)",
+                    "mcp__unity"
+                  ]
+                }
+              }
 
           # Guardrails
           model: "claude-3-7-sonnet-20250219"


### PR DESCRIPTION
## Summary
- enable auto-approval for Claude NL/T test suite by adding explicit settings block

## Testing
- `pytest -q`
- `yamllint .github/workflows/claude-nl-suite.yml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5d2737ed88327ac3192b302031e6b