### PR TITLE
Add disallowed tools to NL suite workflow

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -221,6 +221,7 @@ jobs:
           claude_args: |
             --mcp-config .claude/mcp.json
             --allowedTools Write,mcp__unity__manage_editor,mcp__unity__list_resources,mcp__unity__read_resource,mcp__unity__apply_text_edits,mcp__unity__script_apply_edits,mcp__unity__validate_script,mcp__unity__find_in_file,Bash(git:*),Bash(mkdir:*),Bash(cat:*),Bash(grep:*),Bash(echo:*)
+            --disallowedTools "TodoWrite,Task"
             --model "claude-3-7-sonnet-latest"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
## Summary
- prevent usage of TodoWrite and Task tools in NL suite workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7ee3c574832786615958c2aad879