### PR TITLE
Fix indentation of fallback JUnit XML in workflow

### DIFF
--- a/.github/workflows/claude-nl-suite.yml
+++ b/.github/workflows/claude-nl-suite.yml
@@ -250,16 +250,16 @@ jobs:
             echo "No JUnit found; writing fallback."
             {
               cat <<'XML'
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="UnityMCP.NL-T" tests="1" failures="1" time="0">
-  <testcase classname="UnityMCP.NL" name="NL-Suite.Execution" time="0.0">
-    <failure><![CDATA[
-Suite ended without producing reports. Likely mid-run tool failure (e.g., stale_file) or driver termination.
-See the 'Run Claude NL suite (single pass)' logs for details.
-    ]]></failure>
-  </testcase>
-</testsuite>
-XML
+              <?xml version="1.0" encoding="UTF-8"?>
+              <testsuite name="UnityMCP.NL-T" tests="1" failures="1" time="0">
+                <testcase classname="UnityMCP.NL" name="NL-Suite.Execution" time="0.0">
+                  <failure><![CDATA[
+              Suite ended without producing reports. Likely mid-run tool failure (e.g., stale_file) or driver termination.
+              See the 'Run Claude NL suite (single pass)' logs for details.
+                  ]]></failure>
+                </testcase>
+              </testsuite>
+              XML
             } > reports/junit-fallback.xml
           fi
 


### PR DESCRIPTION
## Summary
- indent fallback JUnit XML so GitHub workflow YAML parses cleanly

## Testing
- `pytest`
- `yamllint .github/workflows/claude-nl-suite.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `actionlint .github/workflows/claude-nl-suite.yml` *(fails: command not found)*
- `go install github.com/rhysd/actionlint/cmd/actionlint@latest` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86ba8ca08327920d55bacd00fb86