### PR TITLE
fix: correct McpTypes reference

### DIFF
--- a/UnityMcpBridge/Editor/Helpers/ConfigJsonBuilder.cs
+++ b/UnityMcpBridge/Editor/Helpers/ConfigJsonBuilder.cs
@@ -54,7 +54,7 @@ namespace MCPForUnity.Editor.Helpers
             // For Cursor (non-VSCode) on macOS, prefer a no-spaces symlink path to avoid arg parsing issues in some runners
             string effectiveDir = directory;
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-            bool isCursor = !isVSCode && (client == null || client.mcpType != Models.McpTypes.VSCode);
+            bool isCursor = !isVSCode && (client == null || client.mcpType != McpTypes.VSCode);
             if (isCursor && !string.IsNullOrEmpty(directory))
             {
                 // Replace canonical path segment with the symlink path if present


### PR DESCRIPTION
## Summary
- Fix ConfigJsonBuilder to use `McpTypes.VSCode` instead of out-of-scope `Models.McpTypes.VSCode`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af07a7e5ac83279b8b679ce759a113