### PR TITLE
fix: only set installation flag after successful server install

### DIFF
--- a/UnityMcpBridge/Editor/Helpers/PackageDetector.cs
+++ b/UnityMcpBridge/Editor/Helpers/PackageDetector.cs
@@ -30,14 +30,11 @@ namespace MCPForUnity.Editor.Helpers
                         try
                         {
                             ServerInstaller.EnsureServerInstalled();
+                            EditorPrefs.SetBool(key, true);
                         }
                         catch (System.Exception ex)
                         {
                             Debug.LogWarning("MCP for Unity: Auto-detect on load failed: " + ex.Message);
-                        }
-                        finally
-                        {
-                            EditorPrefs.SetBool(key, true);
                         }
                     };
                 }


### PR DESCRIPTION
## Summary
- avoid marking auto-detect as completed when server install fails by setting `EditorPrefs` flag only after `EnsureServerInstalled` succeeds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af08ecb8508327bbf4ae7b23abc233