### PR TITLE
fix: respect mac config paths

### DIFF
--- a/UnityMcpBridge/Editor/Data/McpClients.cs
+++ b/UnityMcpBridge/Editor/Data/McpClients.cs
@@ -19,6 +19,11 @@ namespace MCPForUnity.Editor.Data
                     ".cursor",
                     "mcp.json"
                 ),
+                macConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".cursor",
+                    "mcp.json"
+                ),
                 linuxConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".cursor",
@@ -35,6 +40,10 @@ namespace MCPForUnity.Editor.Data
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".claude.json"
                 ),
+                macConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude.json"
+                ),
                 linuxConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".claude.json"
@@ -47,6 +56,12 @@ namespace MCPForUnity.Editor.Data
             {
                 name = "Windsurf",
                 windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".codeium",
+                    "windsurf",
+                    "mcp_config.json"
+                ),
+                macConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".codeium",
                     "windsurf",
@@ -122,6 +137,12 @@ namespace MCPForUnity.Editor.Data
             {
                 name = "Kiro",
                 windowsConfigPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".kiro",
+                    "settings",
+                    "mcp.json"
+                ),
+                macConfigPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".kiro",
                     "settings",

--- a/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/ManualConfigEditorWindow.cs
@@ -119,7 +119,7 @@ namespace MCPForUnity.Editor.Windows
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     displayPath = string.IsNullOrEmpty(mcpClient.macConfigPath)
-                        ? mcpClient.linuxConfigPath
+                        ? configPath
                         : mcpClient.macConfigPath;
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
## Summary
- ensure manual config window shows caller-provided path when macConfigPath missing
- add mac config paths for Cursor, Claude Code, Windsurf, and Kiro clients

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0de95b308327b01747dbe27a6024