### PR TITLE
Use File.Replace for atomic config write

### DIFF
--- a/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/MCPForUnityEditorWindow.cs
@@ -1221,9 +1221,12 @@ namespace MCPForUnity.Editor.Windows
 				// Atomic move operation (more reliable than Replace on macOS)
 				if (System.IO.File.Exists(configPath))
 				{
-					System.IO.File.Delete(configPath);
+					System.IO.File.Replace(tmp, configPath, backup);
 				}
-				System.IO.File.Move(tmp, configPath);
+				else
+				{
+					System.IO.File.Move(tmp, configPath);
+				}
 				
 				// Clean up backup
 				if (System.IO.File.Exists(backup))


### PR DESCRIPTION
## Summary
- Replace delete-and-move sequence with File.Replace to eliminate race conditions when updating config
- Fallback to File.Move when destination file doesn't exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0e06604c8327a97d4764caac8a54