### PR TITLE
Remove unused imports in manage_script

### DIFF
--- a/UnityMcpBridge/UnityMcpServer~/src/tools/manage_script.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/manage_script.py
@@ -1,10 +1,8 @@
 from mcp.server.fastmcp import FastMCP, Context
 from typing import Dict, Any, List
-from unity_connection import get_unity_connection, send_command_with_retry
-from config import config
-import time
-import os
+from unity_connection import send_command_with_retry
 import base64
+import os
 
 
 def register_manage_script_tools(mcp: FastMCP):


### PR DESCRIPTION
## Summary
- remove unused imports from manage_script tools module

## Testing
- `python -m ruff check -v UnityMcpBridge/UnityMcpServer~/src/tools/manage_script.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0e6364f8832790a373802c152175