### PR TITLE
feat: add docker runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ If Auto-Setup fails or you use a different client:
 
 On Windows, set `command` to the absolute shim, e.g. `C:\\Users\\YOU\\AppData\\Local\\Microsoft\\WinGet\\Links\\uv.exe`.
 
+**Docker runtime (all OS)**
+
+```json
+{
+  "servers": {
+    "unityMCP": {
+      "command": "docker",
+      "args": [
+        "run","--rm","-i","--pull=missing",
+        "--name","unity-mcp",
+        "-v","unity_mcp_uv_cache:/opt/uv-cache",
+        "-e","UNITY_HOST=host.docker.internal",
+        "ghcr.io/coplaydev/unity-mcp-server:<VERSION>"
+      ],
+      "type": "stdio"
+    }
+  }
+}
+```
+
+For Linux add: `"--add-host","host.docker.internal:host-gateway"` before the image name.
+
 **Windows:**
 
   ```json

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/ManualConfigJsonBuilderTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Windows/ManualConfigJsonBuilderTests.cs
@@ -50,5 +50,20 @@ namespace MCPForUnityTests.Editor.Windows
             Assert.IsNull(unity["disabled"], "disabled should not be added for Cursor");
             Assert.IsNull(unity["type"], "type should not be added for non-VSCode clients");
         }
+
+        [Test]
+        public void VSCode_DockerJson_UsesDockerCommand()
+        {
+            var client = new McpClient { name = "VSCode", mcpType = McpTypes.VSCode };
+            string[] args = new[] { "run", "--rm", "image" };
+            string json = ConfigJsonBuilder.BuildDockerConfigJson("docker", args, client);
+
+            var root = JObject.Parse(json);
+            var unity = (JObject)root.SelectToken("servers.unityMCP");
+            Assert.NotNull(unity, "Expected servers.unityMCP node");
+            Assert.AreEqual("docker", (string)unity["command"]);
+            CollectionAssert.AreEqual(args, unity["args"].ToObject<string[]>());
+            Assert.AreEqual("stdio", (string)unity["type"]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add docker runtime fallback in server installer
- generate docker config JSON blocks
- update editor window to write docker-based MCP config
- document docker config snippet and test JSON builder

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92203b908832783160bb986e7c5d7