### PR TITLE
Add tool_result pruning utility

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -46,6 +46,27 @@ Restores original files from backup.
 2. Allows you to select which backup to restore
 3. Restores both Unity Bridge and Python Server files
 
+### `prune_tool_results.py`
+Compacts large `tool_result` blobs in conversation JSON into concise one-line summaries.
+
+**Usage:**
+```bash
+python3 prune_tool_results.py < reports/claude-execution-output.json > reports/claude-execution-output.pruned.json
+```
+
+The script reads a conversation from `stdin` and writes the pruned version to `stdout`, making logs much easier to inspect or archive.
+
+### Lean Tool Responses
+To keep live conversations small, server tools now emit minimal payloads by default:
+
+* `find_in_file` – first match positions only (`startLine/Col`, `endLine/Col`).
+* `read_console` – error entries trimmed to `{level, message}` (pass `count` to limit).
+* `validate_script` – diagnostics summarized as `{warnings, errors}` counts.
+* `get_sha` – `{sha256, lengthBytes}` only.
+* `read_resource` – returns only `metadata.sha256` and byte length unless `include_text` or window arguments are provided.
+
+These defaults dramatically cut token usage without affecting essential information.
+
 ## Finding Unity Package Cache Path
 
 Unity stores Git packages under a version-or-hash folder. Expect something like:

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/manage_script.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/manage_script.py
@@ -416,6 +416,11 @@ def register_manage_script_tools(mcp: FastMCP):
             "level": level,
         }
         resp = send_command_with_retry("manage_script", params)
+        if isinstance(resp, dict) and resp.get("success"):
+            diags = resp.get("data", {}).get("diagnostics", []) or []
+            warnings = sum(d.get("severity", "").lower() == "warning" for d in diags)
+            errors = sum(d.get("severity", "").lower() in ("error", "fatal") for d in diags)
+            return {"success": True, "data": {"warnings": warnings, "errors": errors}}
         return resp if isinstance(resp, dict) else {"success": False, "message": str(resp)}
 
     @mcp.tool(description=(
@@ -588,6 +593,15 @@ def register_manage_script_tools(mcp: FastMCP):
             name, directory = _split_uri(uri)
             params = {"action": "get_sha", "name": name, "path": directory}
             resp = send_command_with_retry("manage_script", params)
+            if isinstance(resp, dict) and resp.get("success"):
+                data = resp.get("data", {})
+                return {
+                    "success": True,
+                    "data": {
+                        "sha256": data.get("sha256"),
+                        "lengthBytes": data.get("lengthBytes"),
+                    },
+                }
             return resp if isinstance(resp, dict) else {"success": False, "message": str(resp)}
         except Exception as e:
             return {"success": False, "message": f"get_sha error: {e}"}

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/read_console.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/read_console.py
@@ -42,9 +42,9 @@ def register_read_console_tools(mcp: FastMCP):
 
         # Set defaults if values are None
         action = action if action is not None else 'get'
-        types = types if types is not None else ['error', 'warning', 'log']
-        format = format if format is not None else 'detailed'
-        include_stacktrace = include_stacktrace if include_stacktrace is not None else True
+        types = types if types is not None else ['error']
+        format = format if format is not None else 'json'
+        include_stacktrace = include_stacktrace if include_stacktrace is not None else False
 
         # Normalize action if it's a string
         if isinstance(action, str):
@@ -70,4 +70,11 @@ def register_read_console_tools(mcp: FastMCP):
 
         # Use centralized retry helper
         resp = send_command_with_retry("read_console", params_dict)
-        return resp if isinstance(resp, dict) else {"success": False, "message": str(resp)} 
+        if isinstance(resp, dict) and resp.get("success"):
+            lines = resp.get("data", {}).get("lines", [])
+            trimmed = [
+                {"level": l.get("level") or l.get("type"), "message": l.get("message") or l.get("text")}
+                for l in lines
+            ]
+            return {"success": True, "data": {"lines": trimmed}}
+        return resp if isinstance(resp, dict) else {"success": False, "message": str(resp)}

--- a/prune_tool_results.py
+++ b/prune_tool_results.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import sys, json, re
+
+def summarize(txt):
+    try:
+        obj = json.loads(txt)
+    except Exception:
+        return f"tool_result: {len(txt)} bytes"
+    data = obj.get("data", {}) or {}
+    msg  = obj.get("message") or obj.get("status") or ""
+    # Common tool shapes
+    if "sha256" in str(data):
+        sha = (data.get("sha256") or "")[:8] + "…" if data.get("sha256") else ""
+        ln  = data.get("lengthBytes") or data.get("length") or ""
+        return f"sha={sha} len={ln}".strip()
+    if "diagnostics" in data:
+        diags = data["diagnostics"] or []
+        w = sum(d.get("severity","" ).lower()=="warning" for d in diags)
+        e = sum(d.get("severity","" ).lower() in ("error","fatal") for d in diags)
+        ok = "OK" if not e else "FAIL"
+        return f"validate: {ok} (warnings={w}, errors={e})"
+    if "matches" in data:
+        m = data["matches"] or []
+        if m:
+            first = m[0]
+            return f"find_in_file: {len(m)} match(es) first@{first.get('line',0)}:{first.get('col',0)}"
+        return "find_in_file: 0 matches"
+    if "lines" in data:  # console
+        lines = data["lines"] or []
+        lvls = {"info":0,"warning":0,"error":0}
+        for L in lines:
+            lvls[L.get("level","" ).lower()] = lvls.get(L.get("level","" ).lower(),0)+1
+        return f"console: {len(lines)} lines (info={lvls.get('info',0)},warn={lvls.get('warning',0)},err={lvls.get('error',0)})"
+    # Fallback: short status
+    return (msg or "tool_result")[:80]
+
+def prune_message(msg):
+    if "content" not in msg: return msg
+    newc=[]
+    for c in msg["content"]:
+        if c.get("type")=="tool_result" and c.get("content"):
+            out=[]
+            for chunk in c["content"]:
+                if chunk.get("type")=="text":
+                    out.append({"type":"text","text":summarize(chunk.get("text","" ))})
+            newc.append({"type":"tool_result","tool_use_id":c.get("tool_use_id"),"content":out})
+        else:
+            newc.append(c)
+    msg["content"]=newc
+    return msg
+
+def main():
+    convo=json.load(sys.stdin)
+    if isinstance(convo, dict) and "messages" in convo:
+        convo["messages"]=[prune_message(m) for m in convo["messages"]]
+    elif isinstance(convo, list):
+        convo=[prune_message(m) for m in convo]
+    json.dump(convo, sys.stdout, ensure_ascii=False)
+main()

--- a/tests/test_find_in_file_minimal.py
+++ b/tests/test_find_in_file_minimal.py
@@ -1,0 +1,45 @@
+import sys
+import pathlib
+import importlib.util
+import types
+import asyncio
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "UnityMcpBridge" / "UnityMcpServer~" / "src"
+sys.path.insert(0, str(SRC))
+
+from tools.resource_tools import register_resource_tools  # type: ignore
+
+class DummyMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, *args, **kwargs):
+        def deco(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return deco
+
+@pytest.fixture()
+def resource_tools():
+    mcp = DummyMCP()
+    register_resource_tools(mcp)
+    return mcp.tools
+
+def test_find_in_file_returns_positions(resource_tools, tmp_path):
+    proj = tmp_path
+    assets = proj / "Assets"
+    assets.mkdir()
+    f = assets / "A.txt"
+    f.write_text("hello world", encoding="utf-8")
+    find_in_file = resource_tools["find_in_file"]
+    loop = asyncio.new_event_loop()
+    try:
+        resp = loop.run_until_complete(
+            find_in_file(uri="unity://path/Assets/A.txt", pattern="world", ctx=None, project_root=str(proj))
+        )
+    finally:
+        loop.close()
+    assert resp["success"] is True
+    assert resp["data"]["matches"] == [{"startLine": 1, "startCol": 7, "endLine": 1, "endCol": 12}]

--- a/tests/test_read_console_trimmed.py
+++ b/tests/test_read_console_trimmed.py
@@ -3,12 +3,11 @@ import pathlib
 import importlib.util
 import types
 
-
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SRC = ROOT / "UnityMcpBridge" / "UnityMcpServer~" / "src"
 sys.path.insert(0, str(SRC))
 
-# stub mcp.server.fastmcp to satisfy imports without full dependency
+# stub mcp.server.fastmcp
 mcp_pkg = types.ModuleType("mcp")
 server_pkg = types.ModuleType("mcp.server")
 fastmcp_pkg = types.ModuleType("mcp.server.fastmcp")
@@ -24,16 +23,13 @@ sys.modules.setdefault("mcp", mcp_pkg)
 sys.modules.setdefault("mcp.server", server_pkg)
 sys.modules.setdefault("mcp.server.fastmcp", fastmcp_pkg)
 
-
 def _load_module(path: pathlib.Path, name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
 
-
-manage_script = _load_module(SRC / "tools" / "manage_script.py", "manage_script_mod")
-
+read_console_mod = _load_module(SRC / "tools" / "read_console.py", "read_console_mod")
 
 class DummyMCP:
     def __init__(self):
@@ -45,31 +41,27 @@ class DummyMCP:
             return fn
         return deco
 
-
 def setup_tools():
     mcp = DummyMCP()
-    manage_script.register_manage_script_tools(mcp)
+    read_console_mod.register_read_console_tools(mcp)
     return mcp.tools
 
-
-def test_get_sha_param_shape_and_routing(monkeypatch):
+def test_read_console_returns_trimmed(monkeypatch):
     tools = setup_tools()
-    get_sha = tools["get_sha"]
+    read_console = tools["read_console"]
 
     captured = {}
 
     def fake_send(cmd, params):
-        captured["cmd"] = cmd
         captured["params"] = params
-        return {"success": True, "data": {"sha256": "abc", "lengthBytes": 1, "lastModifiedUtc": "2020-01-01T00:00:00Z", "uri": "unity://path/Assets/Scripts/A.cs", "path": "Assets/Scripts/A.cs"}}
+        return {
+            "success": True,
+            "data": {"lines": [{"level": "error", "message": "oops", "time": "t"}]},
+        }
 
-    monkeypatch.setattr(manage_script, "send_command_with_retry", fake_send)
+    monkeypatch.setattr(read_console_mod, "send_command_with_retry", fake_send)
+    monkeypatch.setattr(read_console_mod, "get_unity_connection", lambda: object())
 
-    resp = get_sha(None, uri="unity://path/Assets/Scripts/A.cs")
-    assert captured["cmd"] == "manage_script"
-    assert captured["params"]["action"] == "get_sha"
-    assert captured["params"]["name"] == "A"
-    assert captured["params"]["path"].endswith("Assets/Scripts")
-    assert resp["success"] is True
-    assert resp["data"] == {"sha256": "abc", "lengthBytes": 1}
-
+    resp = read_console(ctx=None, count=10)
+    assert resp == {"success": True, "data": {"lines": [{"level": "error", "message": "oops"}]}}
+    assert captured["params"]["count"] == 10

--- a/tests/test_read_resource_minimal.py
+++ b/tests/test_read_resource_minimal.py
@@ -1,0 +1,70 @@
+import sys
+import pathlib
+import asyncio
+import types
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "UnityMcpBridge" / "UnityMcpServer~" / "src"
+sys.path.insert(0, str(SRC))
+
+# Stub mcp.server.fastmcp to satisfy imports without full package
+mcp_pkg = types.ModuleType("mcp")
+server_pkg = types.ModuleType("mcp.server")
+fastmcp_pkg = types.ModuleType("mcp.server.fastmcp")
+
+class _Dummy:
+    pass
+
+fastmcp_pkg.FastMCP = _Dummy
+fastmcp_pkg.Context = _Dummy
+server_pkg.fastmcp = fastmcp_pkg
+mcp_pkg.server = server_pkg
+sys.modules.setdefault("mcp", mcp_pkg)
+sys.modules.setdefault("mcp.server", server_pkg)
+sys.modules.setdefault("mcp.server.fastmcp", fastmcp_pkg)
+
+from tools.resource_tools import register_resource_tools  # type: ignore
+
+
+class DummyMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, *args, **kwargs):
+        def deco(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return deco
+
+
+@pytest.fixture()
+def resource_tools():
+    mcp = DummyMCP()
+    register_resource_tools(mcp)
+    return mcp.tools
+
+
+def test_read_resource_minimal_metadata_only(resource_tools, tmp_path):
+    proj = tmp_path
+    assets = proj / "Assets"
+    assets.mkdir()
+    f = assets / "A.txt"
+    content = "hello world"
+    f.write_text(content, encoding="utf-8")
+
+    read_resource = resource_tools["read_resource"]
+    loop = asyncio.new_event_loop()
+    try:
+        resp = loop.run_until_complete(
+            read_resource(uri="unity://path/Assets/A.txt", ctx=None, project_root=str(proj))
+        )
+    finally:
+        loop.close()
+
+    assert resp["success"] is True
+    data = resp["data"]
+    assert "text" not in data
+    meta = data["metadata"]
+    assert "sha256" in meta and len(meta["sha256"]) == 64
+    assert meta["lengthBytes"] == len(content.encode("utf-8"))

--- a/tests/test_validate_script_summary.py
+++ b/tests/test_validate_script_summary.py
@@ -3,12 +3,11 @@ import pathlib
 import importlib.util
 import types
 
-
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SRC = ROOT / "UnityMcpBridge" / "UnityMcpServer~" / "src"
 sys.path.insert(0, str(SRC))
 
-# stub mcp.server.fastmcp to satisfy imports without full dependency
+# stub mcp.server.fastmcp similar to test_get_sha
 mcp_pkg = types.ModuleType("mcp")
 server_pkg = types.ModuleType("mcp.server")
 fastmcp_pkg = types.ModuleType("mcp.server.fastmcp")
@@ -24,16 +23,13 @@ sys.modules.setdefault("mcp", mcp_pkg)
 sys.modules.setdefault("mcp.server", server_pkg)
 sys.modules.setdefault("mcp.server.fastmcp", fastmcp_pkg)
 
-
 def _load_module(path: pathlib.Path, name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
 
-
 manage_script = _load_module(SRC / "tools" / "manage_script.py", "manage_script_mod")
-
 
 class DummyMCP:
     def __init__(self):
@@ -45,31 +41,28 @@ class DummyMCP:
             return fn
         return deco
 
-
 def setup_tools():
     mcp = DummyMCP()
     manage_script.register_manage_script_tools(mcp)
     return mcp.tools
 
-
-def test_get_sha_param_shape_and_routing(monkeypatch):
+def test_validate_script_returns_counts(monkeypatch):
     tools = setup_tools()
-    get_sha = tools["get_sha"]
-
-    captured = {}
+    validate_script = tools["validate_script"]
 
     def fake_send(cmd, params):
-        captured["cmd"] = cmd
-        captured["params"] = params
-        return {"success": True, "data": {"sha256": "abc", "lengthBytes": 1, "lastModifiedUtc": "2020-01-01T00:00:00Z", "uri": "unity://path/Assets/Scripts/A.cs", "path": "Assets/Scripts/A.cs"}}
+        return {
+            "success": True,
+            "data": {
+                "diagnostics": [
+                    {"severity": "warning"},
+                    {"severity": "error"},
+                    {"severity": "fatal"},
+                ]
+            },
+        }
 
     monkeypatch.setattr(manage_script, "send_command_with_retry", fake_send)
 
-    resp = get_sha(None, uri="unity://path/Assets/Scripts/A.cs")
-    assert captured["cmd"] == "manage_script"
-    assert captured["params"]["action"] == "get_sha"
-    assert captured["params"]["name"] == "A"
-    assert captured["params"]["path"].endswith("Assets/Scripts")
-    assert resp["success"] is True
-    assert resp["data"] == {"sha256": "abc", "lengthBytes": 1}
-
+    resp = validate_script(None, uri="unity://path/Assets/Scripts/A.cs")
+    assert resp == {"success": True, "data": {"warnings": 1, "errors": 2}}


### PR DESCRIPTION
## Summary
- add `prune_tool_results.py` to condense tool_result JSON outputs into one-line summaries
- trim default Unity MCP tool payloads: `find_in_file` returns first match positions only, `validate_script` & `get_sha` provide condensed counts and hashes, `read_console` trims entries, and `read_resource` returns only hash and byte length unless text is requested
- document lean tool responses and add tests for trimmed outputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcbbf232cc832791102f8596bd5683